### PR TITLE
Added a script which calculates chart datum for field observations using kartverket API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ The original task description is provided in [task.md](./task.md).
 
 Submit a code review on the pull request. The code example is real and we want you you give constructive feedback on the solution. Please use the github pull request commenting system. 
 
+In addition, we would like to you give some remarks the following:
+- How can the code be improved
+- what are the limitations of the provided solution
+
 PS: remember to click **submit review** when you are done. If not, comments are not visible for others.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,11 @@
-# Tidal adjustment of depth data
+## Tidal challenge code review task
 
-The purpose of this repo is to be used as a coding challenge during interviews.
+You are given a code solution and we want you to perform a code review. We do not expect you to write your own code, just comment on the existing one.
 
-## Description
-
-When our researchers are in the field they often collect data with depth information/measurements.
-These depth measurements are simply taken by the researcher/field technician in the field, and they are
-thus not adjusted and referenced to chart datum (Norwegian “sjøkartnull”).
-The data is usually punched in manually in an MS Excel spreadsheet for further processing (typically one
-row pr. observation), etc.
-
-## Task
-
-Using the supplied Excel file (tidal_sample.xlsx) with depth data (one observation pr. row) you should write a script
-in a language of your choice which:
-- Reads the excel file with sample data
-- relevant columns:
-  - Date
-  - Time
-  - GPS Latitude
-  - GPS Longitude
-  - depth
-- Use the API from the Norwegian mapping authority (Kartverket) to find the water level for each observation with reference to chart datum (sjøkartnull)
-- Calculate chart datum (sjøkartnull) referenced sampling depth for each data row in the spreadsheet
-- Return the result in an appropriate format for further processing
-  - For yourself
-  - For the researcher producing the data
-
-The API for tidal water level adjustment is described here: http://api.sehavniva.no/tideapi_en.html
-
-You can assume the following:
-  - All time stamps are from the Norwegian time zone (i.e. "Europe/Oslo" including daylight saving time).
-  - The coordinates are in WGS84 coordinate system (standard for GPS)
+The original task description is provided in [task.md](./task.md).
 
 ## Deliverables
 
-Please bring the code (either on your own machine or do a private github fork) and prepare a short oral presentation of your work in the interview.
+Submit a code review on the pull request. The code example is real and we want you you give constructive feedback on the solution. Please use the github pull request commenting system. 
+
+PS: remember to click **submit review** when you are done. If not, comments are not visible for others.

--- a/task.md
+++ b/task.md
@@ -1,0 +1,30 @@
+## Description
+
+When our researchers are in the field they often collect data with depth information/measurements.
+These depth measurements are simply taken by the researcher/field technician in the field, and they are
+thus not adjusted and referenced to chart datum (Norwegian “sjøkartnull”).
+The data is usually punched in manually in an MS Excel spreadsheet for further processing (typically one
+row pr. observation), etc.
+
+## Task
+
+Using the supplied Excel file (tidal_sample.xlsx) with depth data (one observation pr. row) you should write a script
+in a language of your choice which:
+- Reads the excel file with sample data
+- relevant columns:
+  - Date
+  - Time
+  - GPS Latitude
+  - GPS Longitude
+  - depth
+- Use the API from the Norwegian mapping authority (Kartverket) to find the water level for each observation with reference to chart datum (sjøkartnull)
+- Calculate chart datum (sjøkartnull) referenced sampling depth for each data row in the spreadsheet
+- Return the result in an appropriate format for further processing
+  - For yourself
+  - For the researcher producing the data
+
+The API for tidal water level adjustment is described here: http://api.sehavniva.no/tideapi_en.html
+
+You can assume the following:
+  - All time stamps are from the Norwegian time zone (i.e. "Europe/Oslo" including daylight saving time).
+  - The coordinates are in WGS84 coordinate system (standard for GPS)

--- a/tidal_challange.py
+++ b/tidal_challange.py
@@ -1,29 +1,10 @@
 ## Date:     29.04.2018 
-## Author:   Zofia Czyczula Rudjord
-## Function: This script calculates chart datum using depth measurements from the field and tidal information from API for water level data. 
+## Function: This script calculates chart datum using depth measurements from the field and tidal information from API for water level data.
 ##           Chart datum is added as an extra column to the input file containing measurements and saved in xlsx file for an easy access by the researchers.
 ##           In addition, the complete information retrieved from API is stored in the output XML for further processing if needed.
 ## Usage:    python tidal_challange.py filename.xlsx 
 ## Output:   filename_out.xlsx 
 ##           filename_out.xml 
-##
-##
-## ----------------------------------------------------------------         
-## -----------Notes------------------------------                                                                                                                 
-## ----------------------------------------------------------------
-## Predicted tidal information (PRE) was used instead of the observation (OBS), although according to API the latter is more precise as it includes 
-## weather effects. OBS returned no data for the time interval of 10 min around the measurement point. In addition predicted point closest (in time) to the measurement
-## is used (in case two points are available, the later one is used). Other options (e.g. interpolation/average) are possible. This should be discussed with researchers.
-##
-## The output xml file if exists could be used instead of the call to the water level API (in line of request stated on the webpage to cache the data)
-## This depends on how excetly the script is going to be used ( e.g. how many times it needs to be executed, etc...)
-##
-## For now, only a limited number of exceptions has been tested and are treated: 
-## -- Nulls/Nans on input: if in Time, Date, GPS coord or Depth column, this measurement is removed. Note that measurements are _not_ reindexed.
-## -- Only data as dd.mm.yyyy and time hh:mm are accepted, if a different format is encountered the measurement is skipped. This can be made more general.
-## -- If API not accessible ( tested with internet off ) no tidal info is available and the code terminates with an error message.
-##
-## This script was tested using Python 2.7.10 (no access to Python 3) on Apple 
 ##
 ## ----------------------------------------------------------------     
 ## -----------Import relevant modules------------------------------

--- a/tidal_challange.py
+++ b/tidal_challange.py
@@ -20,12 +20,7 @@ from xml.etree.ElementTree import ElementTree
 from datetime import datetime   ## for formating date and time
 from datetime import timedelta
 from datetime import time
-## ----------------------------------------------------------------                                                                                                               
-## -----------Constants--------------------------------------------                                                                                                                ## ----------------------------------------------------------------  
-## Depth measurements are in [m] (actually this information is not provided anywhere but it is assumed they are)  
-## while tidal info extracted from API is in [cm]
-## Calculated chart datum is in [m]
-## In pratice information on units should be extracted from excel (NA for now) and from api and not hardcoded
+
 unit        = 100 
 ## ----------------------------------------------------------------
 ## -----------Support functions -----------------------------------

--- a/tidal_challange.py
+++ b/tidal_challange.py
@@ -82,8 +82,8 @@ def format_datetime(da,ti,lower=True,inter=5):
             dati_ = (dati + half_int).strftime("%Y-%m-%dT%H:%M")
         return dati_    
     except ValueError:
-        print "Error: Point ",index, " Time: ", row['Time'], " Date: ", row['Date'], " has wrong format"
-        print "Info: Required time format: H:M, required date format: dd.mm.yy"
+        print("Error: Point ",index, " Time: ", row['Time'], " Date: ", row['Date'], " has wrong format")
+        print("Info: Required time format: H:M, required date format: dd.mm.yy")
         if lower==True :
             dati_ = "1000-00-00T00:00"
         else:
@@ -97,7 +97,7 @@ def save_xml(xml_et, filename):
         except IOError as er:
             print(str(er))
     else:
-        print "No valid XML tree"
+        print("No valid XML tree")
 
 def read_xlsx(input_file):
     try:
@@ -150,8 +150,8 @@ for index, row in df.iterrows():
     try:
         rs = rq.get(URL,params=inputs)
     except rq.exceptions.RequestException as er:  
-        print str(er)
-        print "Error: Retrieving data failed "
+        print(str(er))
+        print("Error: Retrieving data failed ")
         chart_datum.at[index] = float('nan')
         continue
 
@@ -161,7 +161,7 @@ for index, row in df.iterrows():
     nPoints  = len(root.findall('.//waterlevel'))
     if nPoints < 1:
         chart_datum.at[index]=float('nan')
-        print "No tidal information for point: ",index, " Time: ", row['Time'], " date: ", row['Date'], "Latitude ", row['GPS Latitude'], "Longitude ", row['GPS Longitude'] 
+        print ("No tidal information for point: ",index, " Time: ", row['Time'], " date: ", row['Date'], "Latitude ", row['GPS Latitude'], "Longitude ", row['GPS Longitude'])
     else:
         for child in root.iter('waterlevel'):
             chart_datum.at[index]=child.attrib['value']

--- a/tidal_challange.py
+++ b/tidal_challange.py
@@ -1,0 +1,204 @@
+## Date:     29.04.2018 
+## Author:   Zofia Czyczula Rudjord
+## Function: This script calculates chart datum using depth measurements from the field and tidal information from API for water level data. 
+##           Chart datum is added as an extra column to the input file containing measurements and saved in xlsx file for an easy access by the researchers.
+##           In addition, the complete information retrieved from API is stored in the output XML for further processing if needed.
+## Usage:    python tidal_challange.py filename.xlsx 
+## Output:   filename_out.xlsx 
+##           filename_out.xml 
+##
+##
+## ----------------------------------------------------------------         
+## -----------Notes------------------------------                                                                                                                 
+## ----------------------------------------------------------------
+## Predicted tidal information (PRE) was used instead of the observation (OBS), although according to API the latter is more precise as it includes 
+## weather effects. OBS returned no data for the time interval of 10 min around the measurement point. In addition predicted point closest (in time) to the measurement
+## is used (in case two points are available, the later one is used). Other options (e.g. interpolation/average) are possible. This should be discussed with researchers.
+##
+## The output xml file if exists could be used instead of the call to the water level API (in line of request stated on the webpage to cache the data)
+## This depends on how excetly the script is going to be used ( e.g. how many times it needs to be executed, etc...)
+##
+## For now, only a limited number of exceptions has been tested and are treated: 
+## -- Nulls/Nans on input: if in Time, Date, GPS coord or Depth column, this measurement is removed. Note that measurements are _not_ reindexed.
+## -- Only data as dd.mm.yyyy and time hh:mm are accepted, if a different format is encountered the measurement is skipped. This can be made more general.
+## -- If API not accessible ( tested with internet off ) no tidal info is available and the code terminates with an error message.
+##
+## This script was tested using Python 2.7.10 (no access to Python 3) on Apple 
+##
+## ----------------------------------------------------------------     
+## -----------Import relevant modules------------------------------
+## ----------------------------------------------------------------    
+import sys
+import pandas as pd             ## for data handling
+import requests as rq           ## for retrieving info from API   
+try:                            ## for manipulating XML tree (try C version if available because its faster)
+    import xml.etree.cElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ElementTree
+from datetime import datetime   ## for formating date and time
+from datetime import timedelta
+from datetime import time
+## ----------------------------------------------------------------                                                                                                               
+## -----------Constants--------------------------------------------                                                                                                                ## ----------------------------------------------------------------  
+## Depth measurements are in [m] (actually this information is not provided anywhere but it is assumed they are)  
+## while tidal info extracted from API is in [cm]
+## Calculated chart datum is in [m]
+## In pratice information on units should be extracted from excel (NA for now) and from api and not hardcoded
+unit        = 100 
+## ----------------------------------------------------------------
+## -----------Support functions -----------------------------------
+## ----------------------------------------------------------------
+def repl(x,a,b):
+    try:
+        return x.replace(a, b)
+    except AttributeError:
+        return x
+
+def format_input(df):
+## Brute force, ok for now, but a more generic version should handle exceptions in a better way
+    try:
+        df=df.replace(to_replace="<Null>",value="nan")
+        df['GPS Longitude'] = df['GPS Longitude'].apply(lambda x: repl(x,',','.'))
+        df['GPS Longitude'] = df['GPS Longitude'].apply(pd.to_numeric,errors='coerce')
+        df['GPS Latitude']  = df['GPS Latitude'].apply(lambda x: repl(x,',','.'))
+        df['GPS Latitude']  = df['GPS Latitude'].apply(pd.to_numeric,errors='coerce')
+        df['depth']         = df['depth'].apply(lambda x: repl(x,',','.'))
+        df['depth']         = df['depth'].apply(pd.to_numeric,errors='coerce')
+        df['Date']          = df['Date'].apply(lambda x: repl(x,'.',' '))
+        df.dropna(axis=0, how='any',subset=['Date','Time','GPS Longitude','GPS Latitude','depth'],inplace=True)
+        return df
+    except:
+        exit('Formating of input data failed')
+
+def format_datetime(da,ti,lower=True,inter=5):
+## Handling of different input data formats could be added instead of throwing exception
+    half_int=timedelta(minutes=inter)
+    try:
+        dati = datetime.strptime("{} {}".format(da, ti), '%d %m %Y %H:%M')                                 
+        if lower==True :                             
+            dati_ = (dati - half_int).strftime("%Y-%m-%dT%H:%M")
+        else:
+            dati_ = (dati + half_int).strftime("%Y-%m-%dT%H:%M")
+        return dati_    
+    except ValueError:
+        print "Error: Point ",index, " Time: ", row['Time'], " Date: ", row['Date'], " has wrong format"
+        print "Info: Required time format: H:M, required date format: dd.mm.yy"
+        if lower==True :
+            dati_ = "1000-00-00T00:00"
+        else:
+            dati_ = "1000-00-00T00:10"
+        return dati_    
+def save_xml(xml_et, filename):
+    if xml_et is not None:
+        try:
+            tree=ElementTree(xml_et)
+            tree.write(filename)
+        except IOError as er:
+            print(str(er))
+    else:
+        print "No valid XML tree"
+
+def read_xlsx(input_file):
+    try:
+        df = pd.read_excel(input_file)
+        return df
+    except IOError as er:
+        print(str(er))
+        sys.exit('Error: Reading input file')
+
+def save_xlsx(df, filename):
+    try:
+        out = pd.ExcelWriter(filename)
+        df.to_excel(out, sheet_name='Sheet1')
+        out.save()
+    except IOError as er:
+        print(str(er))
+        sys.exit('Error: Writing Excel file')
+
+## ---------------------------------------------------------------- 
+## -----------Input -----------------------------------------------
+## ---------------------------------------------------------------- 
+if len(sys.argv) < 2:
+    print("Usage: python tidal_challange.py filename.xlsx")
+    sys.exit('Error: too few arguments, please specify an input filename')
+
+input_file = str(sys.argv[1])        ## input file name
+df         = read_xlsx(input_file)   ## read in data from excel and store in a dataframe
+df         = format_input(df)        ## Format columns in convenient way for further processing
+
+## ----------------------------------------------------------------                                                                                                            
+## -----------Main body-------------------------------------------- 
+## ----------------------------------------------------------------         
+xml_ET      = None                   ## define XML output tree
+chart_datum = pd.Series()            ## array of chart datum
+URL         = "http://api.sehavniva.no/tideapi.php"  ## API URL
+daty        = 'PRE'
+## Loop over measurements. For each measurement point (date, time) extract tidal information by calling API for water level
+## Store tidal information in a series indexed by measurements                                                             
+## If measured point lies exactly in the middle of the time interval, there are two tidal points returned by API.                                                                    
+## For now the later point is used. Other options (such e.g. linear interpolation/average) can be added depending on requested precision              
+
+for index, row in df.iterrows():
+
+## Create dictionary of input parameters for API 
+    fromtime = format_datetime(row['Date'],row['Time'])
+    totime = format_datetime(row['Date'],row['Time'],lower=False)
+    inputs={'tide_request':'locationdata','lat':row['GPS Latitude'],'lon':row['GPS Longitude'],'datatype':daty,'refcode':'CD','fromtime':fromtime,'totime':totime,'interval':'10'}
+
+## Get waterlevel data by calling the API   
+    try:
+        rs = rq.get(URL,params=inputs)
+    except rq.exceptions.RequestException as er:  
+        print str(er)
+        print "Error: Retrieving data failed "
+        chart_datum.at[index] = float('nan')
+        continue
+
+## Create XML tree from API output string
+    root     = ET.fromstring(rs.content)
+## Store tidal values in chart_datum series 
+    nPoints  = len(root.findall('.//waterlevel'))
+    if nPoints < 1:
+        chart_datum.at[index]=float('nan')
+        print "No tidal information for point: ",index, " Time: ", row['Time'], " date: ", row['Date'], "Latitude ", row['GPS Latitude'], "Longitude ", row['GPS Longitude'] 
+    else:
+        for child in root.iter('waterlevel'):
+            chart_datum.at[index]=child.attrib['value']
+
+## Store API output in an xml tree 
+    for child in root.iter('tide'):
+        if xml_ET is None:
+            xml_ET = root 
+        else:
+            xml_ET.extend(child) 
+
+## ----------------------------------------------------------------     
+## -----------Store results----------------------------------------  
+## ----------------------------------------------------------------     
+
+## Derive output file names 
+## Ok for now but a generic version should allow for different input and output paths as well as a more robust deriviation of output filenames. 
+name=input_file[:-5]
+output_file1=name+"_out.xml"
+output_file2=name+"_out.xlsx"
+
+## Check wether there exist at least one valid waterlevel tidal point                                                                                                             
+if(chart_datum.isnull().all()):
+    sys.exit('Error: no waterlavel data')
+
+## Save API output in xml file
+save_xml(xml_ET, output_file1)
+
+## Format tidal information, calculate chart datum and add it as an extra column to the existing data
+## Note: measurements are not re-indexed after removing Nulls from the input
+chart_datum     = chart_datum.apply(pd.to_numeric)            ## convert string to numerical values
+dpth            = pd.Series(df['depth'])                      ## convert depth info to a series
+chart_datum     = -chart_datum/unit + dpth                    ## calculate chart datum
+df['Date']      = df['Date'].apply(lambda x: repl(x,' ','.')) ## go back to the original date format
+df.insert(6,'chart_datum',chart_datum)                        ## insert the chart datum column
+
+## Save the result in an excel file
+save_xlsx(df, output_file2)
+
+


### PR DESCRIPTION
Predicted tidal information (PRE) was used instead of the observation (OBS), although according to API the latter is more precise as it includes 
weather effects. OBS returned no data for the time interval of 10 min around the measurement point. In addition predicted point closest (in time) to the measurement
is used (in case two points are available, the later one is used). Other options (e.g. interpolation/average) are possible. This should be discussed with researchers.

The output xml file if exists could be used instead of the call to the water level API (in line of request stated on the webpage to cache the data)
This depends on how excetly the script is going to be used ( e.g. how many times it needs to be executed, etc...)

## Details
- Depth measurements are in [m] (actually this information is not provided anywhere but it is assumed they are) while tidal info extracted from API is in [cm]
- Calculated chart datum is in [m]
- In pratice information on units should be extracted from excel (NA for now) and from api and not hardcoded